### PR TITLE
Ignores build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 
+# Build artifacts
+lib/build-info.json
+
 # Optional npm cache directory
 .npm
 


### PR DESCRIPTION
Excludes the `lib/build-info.json` file from being tracked by Git.
This prevents build-specific information from being committed.