### PR TITLE
Uses dedicated token for release creation

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -218,7 +218,7 @@ jobs:
       - name: 🏷️ Create GitHub Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           release_name: Release v${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
Updates the workflow to utilize a dedicated GitHub token for creating releases.

This enhances security and avoids unintended consequences associated with using the default `GITHUB_TOKEN`.