### PR TITLE
Fixes: Loads inquirer as an ES module

### DIFF
--- a/scripts/setup-env.js
+++ b/scripts/setup-env.js
@@ -1,11 +1,28 @@
 #!/usr/bin/env node
 
-const inquirer = require('inquirer');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const chalk = require('chalk');
 const { setupGitExtension } = require('./setup-git-extension');
+
+// For inquirer v12+, we need to use dynamic import since it's an ES module
+let inquirer;
+
+async function loadInquirer() {
+  if (!inquirer) {
+    try {
+      // Dynamic import for ES module
+      const inquirerModule = await import('inquirer');
+      inquirer = inquirerModule.default || inquirerModule;
+    } catch (error) {
+      console.error(chalk.red('❌ Error loading inquirer:'), error.message);
+      console.error(chalk.yellow('Please try: npm install inquirer'));
+      process.exit(1);
+    }
+  }
+  return inquirer;
+}
 
 // Import constants from compiled JavaScript
 const { CONFIG, DEFAULT_MODELS, SYSTEM } = require('../lib/constants');
@@ -25,6 +42,9 @@ function getConfigFilePath() {
 
 async function setupEnvironment() {
     console.log(chalk.blue('🚀 Environment Setup Wizard'));
+    
+    // Load inquirer first
+    await loadInquirer();
     console.log(chalk.gray('This will collect your environment configuration and save it for global use.\n'));
 
     // Load existing configuration if available
@@ -425,6 +445,9 @@ function validateConfig(config) {
 
 // Helper function to update existing configuration
 async function updateConfiguration() {
+    // Load inquirer first
+    await loadInquirer();
+    
     if (!configExists()) {
         console.log(chalk.yellow('No existing configuration found. Running initial setup...'));
         return await setupEnvironment();


### PR DESCRIPTION
Addresses an issue where `inquirer` needs to be loaded as an ES module using a dynamic import.

This change ensures compatibility with newer versions of `inquirer` (v12+) which are distributed as ES modules. It implements a dynamic import mechanism with error handling to gracefully manage cases where `inquirer` might not be installed, providing guidance to the user.

## Ticket URL
<!-- 
Please include the URL to the related ticket or issue here. 
Example: https://jira.yourcompany.com/browse/PROJECT-123
-->

---

## Summary of Changes
<!-- 
Provide a brief description of the changes introduced in this PR. 
Focus on *what* was changed and *why*. Avoid excessive technical detail here — that can go in comments or the commit message.
-->

---

## Test Plan
<!-- 
Describe the steps reviewers can follow to test and verify the changes.
Include any setup, test data, commands, or special considerations. 
-->

**Expected Result:** 

---

## Checklist
<!-- 
Mark completed items with [x]. These help ensure the PR is ready for review and merge.
-->

- [ ] Ticket URL linked above
- [ ] Code follows team coding standards
- [ ] Tests added or updated
- [ ] Verified locally
- [ ] No console errors or warnings
- [ ] Ready for final review
